### PR TITLE
Ubuntu image: disable unattended upgrades

### DIFF
--- a/googlecompute/ubuntu_images.json
+++ b/googlecompute/ubuntu_images.json
@@ -53,6 +53,12 @@
     {
       "type": "shell",
       "inline": [
+        "cp /usr/share/unattended-upgrades/20auto-upgrades-disabled /etc/apt/apt.conf.d/"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq openjdk-14-jdk",
         "sudo apt-get install -y python3-pip python3-dev build-essential",
         "sudo apt-get install -y ruby-dev",

--- a/googlecompute/ubuntu_images.json
+++ b/googlecompute/ubuntu_images.json
@@ -47,6 +47,7 @@
       "type": "shell",
       "inline": [
         "sudo apt-get update -y",
+        "sudo apt-get update -y",
         "sudo apt-get install -y -qq git vim build-essential zip"
       ]
     },

--- a/googlecompute/ubuntu_images.json
+++ b/googlecompute/ubuntu_images.json
@@ -53,7 +53,7 @@
     {
       "type": "shell",
       "inline": [
-        "cp /usr/share/unattended-upgrades/20auto-upgrades-disabled /etc/apt/apt.conf.d/"
+        "sudo cp /usr/share/unattended-upgrades/20auto-upgrades-disabled /etc/apt/apt.conf.d/"
       ]
     },
     {


### PR DESCRIPTION
Since these images are supposed to be ephemeral, unattended upgrades won't help and will only introduce things like:

```
Fetched 3668 kB in 1s (3360 kB/s)
Reading package lists...
sudo apt-get -y upgrade
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 1962 (unattended-upgr)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
Exit status: 100
```

...when running `docker_builder` tasks.