### PR TITLE
Include Python venv module in the Docker builder image

### DIFF
--- a/googlecompute/ubuntu_images.json
+++ b/googlecompute/ubuntu_images.json
@@ -101,7 +101,7 @@
     {
       "type": "shell",
       "inline": [
-        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-17-jdk python3-pip python3-dev",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-17-jdk python3-pip python3-dev python3-venv",
         "sudo pip3 install docker-compose --upgrade",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ruby-dev",
         "sudo gem install bundler"


### PR DESCRIPTION
Debian-based distros don't include the venv and ensurepip module from Python's standard library in the base python package so it needs to be installed separately.