### PR TITLE
Install docker-compose from APT

### DIFF
--- a/googlecompute/ubuntu_images.json
+++ b/googlecompute/ubuntu_images.json
@@ -86,7 +86,7 @@
       "type": "shell",
       "inline": [
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-21-jdk python3-pip python3-dev python3-venv",
-        "sudo pip3 install docker-compose --upgrade",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-compose",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ruby-dev",
         "sudo gem install bundler"
       ],


### PR DESCRIPTION
As far as I understand `sudo pip3 install` is what causes the build to fail:

<img width="1181" height="487" alt="Screenshot 2025-07-22 at 14 35 52" src="https://github.com/user-attachments/assets/8e83af18-d3f3-4e2b-860a-94d9d0481f37" />
