### PR TITLE
kvm: explicitly set machine type to `n1-standard-2`

### DIFF
--- a/googlecompute/ubuntu_images.json
+++ b/googlecompute/ubuntu_images.json
@@ -38,6 +38,7 @@
       "image_name": "docker-kvm-{{user `current_date`}}",
       "image_family": "docker-kvm",
       "disk_size": "100",
+      "machine_type": "n1-standard-2",
       "min_cpu_platform": "Intel Haswell",
       "image_licenses": ["projects/vm-options/global/licenses/enable-vmx"],
       "ssh_username": "root",


### PR DESCRIPTION
Otherwise the following error is shown:

<img width="1148" height="523" alt="Screenshot 2025-07-22 at 14 54 21" src="https://github.com/user-attachments/assets/ae742698-eacd-4525-9a44-72a3a4da6778" />
